### PR TITLE
shortened unittests function in sql_csv_utils and test_sql_tools.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/tax_dump.sql
 **/run_picdb.sh
 **/dummy_cleaner.py
 **/picdb_config.py

--- a/image_client/picturae_importer.py
+++ b/image_client/picturae_importer.py
@@ -578,11 +578,10 @@ class PicturaeImporter(Importer):
 
     def create_taxon(self):
         """create_taxon: populates the taxon table iteratively by adding higher taxa first,
-                            before lower taxa. Assigns taxa ranks and TaxonTreedefItemID.
-                        Using parent list in order to populate parent ids, by using the parsed
-                        rank levels of each taxon name.
+                         before lower taxa. Assigns taxa ranks and TaxonTreedefItemID.
+                         Using parent list in order to populate parent ids, by using the parsed
+                         rank levels of each taxon name.
         """
-        # for now do not upload
         self.parent_list = [self.full_name, self.first_intra, self.gen_spec, self.genus, self.family_name]
         self.parent_list = unique_ordered_list(self.parent_list)
         for index, taxon in reversed(list(enumerate(self.taxon_list))):
@@ -642,8 +641,6 @@ class PicturaeImporter(Importer):
                 args through create_sql_string and create_table record
                 in order to add new collectionobject record to database.
         """
-        # will new collecting event ids need to be created ?
-        # re-pulling collecting event id to reflect new record
 
         self.collecting_event_id = self.sql_csv_tools.get_one_match(tab_name='collectingevent',
                                                                     id_col='CollectingEventID',

--- a/image_client/sql_csv_utils.py
+++ b/image_client/sql_csv_utils.py
@@ -136,7 +136,6 @@ class SqlCsvTools():
         cursor = self.get_cursor()
         logger_int.info(f'running query: {sql}')
         logger_int.debug(sql)
-
         try:
             cursor.execute(sql)
         except Exception as e:

--- a/tests/casbotany_lite_creator.py
+++ b/tests/casbotany_lite_creator.py
@@ -388,9 +388,9 @@ def table_sql_list():
 
 
 def casbotany_lite_creator():
-    """casbotqny_lite_creator: casbotany_lite_creator: creates the
+    """casbotany_lite_creator: casbotany_lite_creator: creates the
                   sqllite tables contained in the sqllite DDL list"""
-    connect = sqlite3.connect('tests/casbotany_lite.db')
+    connect = sqlite3.connect('casbotany_lite.db')
     sql_list = table_sql_list()
     curs = connect.cursor()
     # running a loop through tables for sql_lite

--- a/tests/pic_importer_test_class.py
+++ b/tests/pic_importer_test_class.py
@@ -10,6 +10,5 @@ class TestPicturaeImporter(PicturaeImporter):
     def __init__(self, date_string, paths):
         Importer.__init__(self, db_config_class=picturae_config, collection_name="Botany")
         self.init_all_vars(date_string=date_string, paths=paths)
-        self.sqlite_csv_tools = SqlLiteTools(sql_db="../tests/casbotany_lite.db")
-        self.sql_csv_tools = SqlCsvTools(config=picturae_config)
+        self.sql_csv_tools = SqlLiteTools(sql_db="../tests/casbotany_lite.db")
         self.logger = logging.getLogger("TestPicturaeImporter")

--- a/tests/tests_readme.txt
+++ b/tests/tests_readme.txt
@@ -5,6 +5,7 @@ testing_tools.py: tools to create fake data and generate unique ids for them to 
 test classes:
     pic_csv_test_class.py: the test class of CsvCreatePicturae, with reduced init method for use in unittests.
     pic_importer_test_class.py: the test class of PicturaeImporter, with reduced init method for use in unittests.
+    sqlite_csv_utils.py: a test class of sql_csv_utils, for sqlite db compatibility
 
 tests for picturae_create_csv file:
     test_pic_dir.py : runs unittests for the functions : file_present
@@ -18,6 +19,7 @@ tests for picturae_importer file:
     test_file_hide.py: runs unittests on hide_unwanted_files and unhide_files
     test_taxontree.py: runs unittests for the populate taxon, generate taxon fields, and insert statements for taxon
                        into taxon tree.
+
 
 
 


### PR DESCRIPTION
This is a small PR:
-Shortened unittest functions for locality and collectionobejct insert in tests/test_sql_tools.py
-Shortened unittest functions for test_taxon_insert in test_taxontree.py

files changed:
tests/test_sql_tools.py
tests/test_taxontree.py